### PR TITLE
Built for 7.1-10

### DIFF
--- a/build/proxmox/build.sh
+++ b/build/proxmox/build.sh
@@ -63,7 +63,7 @@ apt -y update
 apt -y install git nano screen patch fakeroot build-essential devscripts libncurses5 libncurses5-dev libssl-dev bc \
  flex bison libelf-dev libaudit-dev libgtk2.0-dev libperl-dev asciidoc xmlto gnupg gnupg2 rsync lintian debhelper \
  libdw-dev libnuma-dev libslang2-dev sphinx-common asciidoc-base automake cpio dh-python file gcc kmod libiberty-dev \
- libpve-common-perl libtool perl-modules python3-minimal sed tar zlib1g-dev lz4 curl zstd
+ libpve-common-perl libtool perl-modules python3-minimal sed tar zlib1g-dev lz4 curl zstd dwarves
 
 
 

--- a/build/proxmox/build7.1-10.sh
+++ b/build/proxmox/build7.1-10.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+export PVE_KERNEL_BRANCH=pve-kernel-5.13
+export RELAX_INTEL_GIT_REPO="https://github.com/OrpheeGT/relax-intel-rmrr.git"
+export RELAX_PATCH="add-relaxable-rmrr-5_13.patch"
+export PROXMOX_PATCH="proxmox7.patch"
+
+./build.sh

--- a/patches/add-relaxable-rmrr-5_13.patch
+++ b/patches/add-relaxable-rmrr-5_13.patch
@@ -1,0 +1,29 @@
+--- a/drivers/iommu/intel/iommu.c       2022-02-26 13:51:33.821885509 +0100
++++ b/drivers/iommu/intel/iommu.c       2022-02-26 13:58:27.231463792 +0100
+@@ -364,6 +364,7 @@
+ static int intel_iommu_superpage = 1;
+ static int iommu_identity_mapping;
+ static int iommu_skip_te_disable;
++static int intel_relaxable_rmrr = 0;
+
+ #define IDENTMAP_GFX           2
+ #define IDENTMAP_AZALIA                4
+@@ -465,6 +466,9 @@
+                } else if (!strncmp(str, "tboot_noforce", 13)) {
+                        pr_info("Intel-IOMMU: not forcing on after tboot. This could expose security risk for tboot\n");
+                        intel_iommu_tboot_noforce = 1;
++               } else if (!strncmp(str, "relax_rmrr", 10)) {
++                        pr_info("Intel-IOMMU: assuming all RMRRs are relaxable. This can lead to instability or data loss\n");
++                        intel_relaxable_rmrr = 1;
+                } else {
+                        pr_notice("Unknown option - '%s'\n", str);
+                }
+@@ -2846,7 +2850,7 @@
+                return false;
+
+        pdev = to_pci_dev(dev);
+-       if (IS_USB_DEVICE(pdev) || IS_GFX_DEVICE(pdev))
++       if (intel_relaxable_rmrr || IS_USB_DEVICE(pdev) || IS_GFX_DEVICE(pdev))
+                return true;
+        else
+                return false;

--- a/patches/add-relaxable-rmrr-5_15.patch
+++ b/patches/add-relaxable-rmrr-5_15.patch
@@ -1,0 +1,29 @@
+--- a/drivers/iommu/intel/iommu.c       2022-02-27 12:02:53.958814198 +0100
++++ b/drivers/iommu/intel/iommu.c       2022-02-27 12:03:07.402842983 +0100
+@@ -338,6 +338,7 @@
+ static int intel_iommu_superpage = 1;
+ static int iommu_identity_mapping;
+ static int iommu_skip_te_disable;
++static int intel_relaxable_rmrr = 0;
+
+ #define IDENTMAP_GFX           2
+ #define IDENTMAP_AZALIA                4
+@@ -442,6 +443,9 @@
+                } else if (!strncmp(str, "tboot_noforce", 13)) {
+                        pr_info("Intel-IOMMU: not forcing on after tboot. This could expose security risk for tboot\n");
+                        intel_iommu_tboot_noforce = 1;
++                } else if (!strncmp(str, "relax_rmrr", 10)) {
++                        pr_info("Intel-IOMMU: assuming all RMRRs are relaxable. This can lead to instability or data loss\n");
++                        intel_relaxable_rmrr = 1;
+                } else {
+                        pr_notice("Unknown option - '%s'\n", str);
+                }
+@@ -2824,7 +2828,7 @@
+                return false;
+
+        pdev = to_pci_dev(dev);
+-       if (IS_USB_DEVICE(pdev) || IS_GFX_DEVICE(pdev))
++       if (intel_relaxable_rmrr || IS_USB_DEVICE(pdev) || IS_GFX_DEVICE(pdev))
+                return true;
+        else
+                return false;


### PR DESCRIPTION
Hello,

When I tried your compiled *.deb file, it did not work, my kernel was still "5.13.19-4-pve"
So I took your docker build files, and encountered some issues while compiling from sources, so I fixed the patch (5_13)

I did not want to break build7.sh so I made a new build7.1-10.sh

Maybe I should have overwrited it...

Once built with : 
RMRR_AUTOINSTALL=1 bash ./build7.1-10.sh

I had :

linux-tools-5.13_5.13.19-10_amd64.deb
linux-tools-5.13-dbgsym_5.13.19-10_amd64.deb
pve-headers-5.13.19-5-pve-relaxablermrr_5.13.19-10_amd64.deb
pve-kernel-5.13.19-5-pve-relaxablermrr_5.13.19-10_amd64.deb
pve-kernel-libc-dev_5.13.19-10_amd64.deb

after reboot : 
# uname -r
5.13.19-5-pve-relaxablermrr

And PCI passthrough works with my LSI HBA IT card.

Feel free to adapt to better standards if needed.

thanks